### PR TITLE
npm config tmp should have precedence over /tmp

### DIFF
--- a/install.js
+++ b/install.js
@@ -74,8 +74,8 @@ npmconf.load(function(err, conf) {
 function findSuitableTempDirectory(npmConf) {
   var now = Date.now(),
     candidateTmpDirs = [
-    process.env.TMPDIR || '/tmp',
-    npmConf.get('tmp'),
+    process.env.TMPDIR || npmConf.get('tmp'),
+    '/tmp',
     path.join(process.cwd(), 'tmp')
   ];
 


### PR DESCRIPTION
Previously /tmp would always be tried before `npmConf.get('tmp')`
